### PR TITLE
Convert to support unittest

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -1,5 +1,8 @@
+#!/usr/bin/env python2
+
 from wtforms import Form, fields
 from wtforms_test import FormTestCase
+import unittest
 
 
 class ExampleForm(Form):
@@ -23,3 +26,6 @@ class TestFormTestCase(FormTestCase):
 
     def test_assert_choice_values(self):
         self.assert_choice_values('select', [(2, 2), (0, 0), (1, 1)])
+
+if __name__ == '__main__':
+    unittest.main()

--- a/wtforms_test/__init__.py
+++ b/wtforms_test/__init__.py
@@ -1,7 +1,6 @@
 import collections
 from wtforms import Field
 import unittest
-
 from wtforms.validators import (
     DataRequired, Length, Email, Optional, NumberRange
 )
@@ -136,6 +135,19 @@ class FormTestCase(unittest.TestCase):
         field = self._get_field(field_name)
         msg = "Field '%s' is not required." % field_name
         assert self._get_validator(field, DataRequired), msg
+
+    def assert_valid(self, data):
+        self.form.process(**data)
+        self.form.validate()
+        for field_name, value in data.iteritems():
+            msg = "Field '%s' with value '%s' was valid" % (field_name, value)
+            assert field_name not in self.form.errors.keys(), msg
+
+    def assert_invalid(self, data, invalid_field):
+        self.form.process(**data)
+        self.form.validate()
+        msg = "Field '%s' with value '%s' was valid" % (invalid_field, self.form.__dict__[invalid_field].data)
+        assert invalid_field in self.form.errors.keys(), msg
 
     def assert_email(self, field_name):
         field = self._get_field(field_name)

--- a/wtforms_test/__init__.py
+++ b/wtforms_test/__init__.py
@@ -1,16 +1,22 @@
 import collections
 from wtforms import Field
+import unittest
 
 from wtforms.validators import (
     DataRequired, Length, Email, Optional, NumberRange
 )
 
 
-class FormTestCase(object):
+class FormTestCase(unittest.TestCase):
     form_class = None
 
-    def _make_form(self, *args, **kwargs):
-        return self.form_class(csrf_enabled=False, *args, **kwargs)
+    @classmethod
+    def setUpClass(cls):
+        cls.form = cls._make_form()
+
+    @classmethod
+    def _make_form(cls, *args, **kwargs):
+        return cls.form_class(csrf_enabled=False, *args, **kwargs)
 
     def _get_field(self, field_name):
         form = self._make_form()


### PR DESCRIPTION
Support unittest, this allows the user to use the standard assert\* methods in addition to the ones previously defined. The form is also only initialised at class setup and not for every _make_form invocation.
